### PR TITLE
fix: backwards compatible TMS URL

### DIFF
--- a/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json
+++ b/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json
@@ -9,6 +9,12 @@
 			"enabled": true
 		},
 		{
+			"key": "ofUrl",
+			"value": "localhost:5000",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "tazamaAdminUrl",
 			"value": "localhost:5100",
 			"type": "default",

--- a/environments/Tazama-LOCAL.postman_environment.json
+++ b/environments/Tazama-LOCAL.postman_environment.json
@@ -9,6 +9,12 @@
 			"enabled": true
 		},
 		{
+			"key": "ofUrl",
+			"value": "localhost:5000",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "tazamaAdminUrl",
 			"value": "localhost:5100",
 			"type": "default",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added an `ofURL` to the environment file in addition to the new `tazamaTMSUrl`.

## Why are we doing this?

Backwards compatibility while we refactor all our tests.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
